### PR TITLE
Fix relationship validation never report parent not found issue.

### DIFF
--- a/src/common/mongo_dao.py
+++ b/src/common/mongo_dao.py
@@ -594,17 +594,43 @@ class MongoDao:
             self.log.exception(f"Failed to update release record: {get_exception_msg()}")
             return False
 
-    """
-    search release by data common, node id and node type
-    """
-    def search_release(self, data_commons, node_type, node_id):
+    def search_node(self, data_commons, node_type, node_id):
+        """
+        Search release collection for given node, if not found, search it in dataRecord collection
+        :param data_commons:
+        :param node_type:
+        :param node_id:
+        :return:
+        """
         db = self.client[self.db_name]
         data_collection = db[RELEASE_COLLECTION]
         try:
             result = data_collection.find_one({DATA_COMMON_NAME: data_commons, NODE_TYPE: node_type, NODE_ID: node_id})
             if not result:
-                # search dataRecords 
+                # search dataRecords
                 result = self.search_node_by_index_crdc(data_commons, node_type, node_id)
+            return result
+        except errors.PyMongoError as pe:
+            self.log.debug(pe)
+            self.log.exception(f"Failed to find release record for {data_commons}/{node_type}/{node_id}: {get_exception_msg()}")
+            return False
+        except Exception as e:
+            self.log.debug(e)
+            self.log.exception(f"Failed to find release record for {data_commons}/{node_type}/{node_id}: {get_exception_msg()}")
+            return False
+
+    def search_released_node(self, data_commons, node_type, node_id):
+        """
+        Search release collection for given node
+        :param data_commons:
+        :param node_type:
+        :param node_id:
+        :return:
+        """
+        db = self.client[self.db_name]
+        data_collection = db[RELEASE_COLLECTION]
+        try:
+            result = data_collection.find_one({DATA_COMMON_NAME: data_commons, NODE_TYPE: node_type, NODE_ID: node_id})
             return result
         except errors.PyMongoError as pe:
             self.log.debug(pe)

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -244,7 +244,7 @@ class DataLoader:
             if not self.data_common or not node_type or not node_id:
                 return None
             else:
-                result = self.mongo_dao.search_release(self.data_common, node_type, node_id)
+                result = self.mongo_dao.search_node(self.data_common, node_type, node_id)
                 return None if not result else result[CRDC_ID]
         else:
             return exist_node.get(CRDC_ID)

--- a/src/metadata_validator.py
+++ b/src/metadata_validator.py
@@ -304,8 +304,7 @@ class MetaDataValidator:
         node_keys = self.model.get_node_keys()
         node_relationships = self.model.get_node_relationships(node_type)
         parent_node_cache = self.get_parent_node_cache(data_record_parent_nodes)
-        data_common, node_type, node_id = data_record.get(DATA_COMMON_NAME), data_record.get(NODE_TYPE), data_record.get(NODE_ID)
-        crdc_record = self.mongo_dao.search_release(data_common, node_type, node_id)
+        data_common = data_record.get(DATA_COMMON_NAME)
         for parent_node in data_record_parent_nodes:
             parent_type = parent_node.get("parentType")
             if not parent_type or parent_type not in node_keys:
@@ -337,7 +336,8 @@ class MetaDataValidator:
                 continue
 
             if (parent_type, parent_id_property, parent_id_value) not in parent_node_cache:
-                if not crdc_record:
+                released_parent = self.mongo_dao.search_released_node(data_common, parent_type, parent_id_value)
+                if not released_parent:
                     result[ERRORS].append(create_error("Related node not found", f'Related node “{parent_type}” [“{parent_id_property}”: “{parent_id_value}"] not found.'))
 
         if len(result[WARNINGS]) > 0:


### PR DESCRIPTION
1. Separate search_release into two, one search release collection only, the other  search release collection then  dataRecord collection
2. Search parent node instead of current node, when validating relationships.