### PR TITLE
Fixed validating both + all bug

### DIFF
--- a/src/common/mongo_dao.py
+++ b/src/common/mongo_dao.py
@@ -239,17 +239,17 @@ class MongoDao:
     """
     update errors in submissions collection
     """   
-    def set_submission_validation_status(self, submission, file_status, metadata_status, msgs, is_delete = False):
+    def set_submission_validation_status(self, submission, file_status, metadata_status, fileErrors, is_delete = False):
         updated_submission = {ID: submission[ID]}
         db = self.client[self.db_name]
         file_collection = db[SUBMISSION_COLLECTION]
         try:
-            if msgs and len(msgs) > 0:
-                updated_submission[FILE_ERRORS] = msgs
-            else: 
-                updated_submission[FILE_ERRORS] = []
             if file_status:
                 updated_submission[FILE_VALIDATION_STATUS] = file_status
+                if fileErrors and len(fileErrors) > 0:
+                    updated_submission[FILE_ERRORS] = fileErrors
+                else:
+                    updated_submission[FILE_ERRORS] = []
             if metadata_status:
                 if (is_delete and self.count_docs(DATA_COLlECTION, {SUBMISSION_ID: submission[ID]}) == 0) or metadata_status == FAILED:
                     metadata_status = None

--- a/src/file_validator.py
+++ b/src/file_validator.py
@@ -74,7 +74,8 @@ def fileValidate(configs, job_queue, mongo_dao):
                         else:
                             status, msgs = validator.validate_all_files(data[SUBMISSION_ID])
                             #update submission
-                        mongo_dao.set_submission_validation_status(validator.submission, status, None, msgs)
+                        update_result = mongo_dao.set_submission_validation_status(validator.submission, status, None, msgs)
+                        log.info(f"Update submission ({submission_id}) status: {update_result}")
                     else:
                         log.error(f'Invalid message: {data}!')
                     

--- a/src/file_validator.py
+++ b/src/file_validator.py
@@ -74,8 +74,7 @@ def fileValidate(configs, job_queue, mongo_dao):
                         else:
                             status, msgs = validator.validate_all_files(data[SUBMISSION_ID])
                             #update submission
-                        update_result = mongo_dao.set_submission_validation_status(validator.submission, status, None, msgs)
-                        log.info(f"Update submission ({submission_id}) status: {update_result}")
+                        mongo_dao.set_submission_validation_status(validator.submission, status, None, msgs)
                     else:
                         log.error(f'Invalid message: {data}!')
                     


### PR DESCRIPTION
The cause of the bug is, due to the use of replace_one instead of update_one, metadata validation can overwrites file validation results if it runs slower than file validation. Opposite situation can also happen in some cases.

The fix is use update_one function and only update the properties need to be updated.