### PR TITLE
Remove useless DB call for performance.

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -73,11 +73,8 @@ class DataLoader:
                     id = self.get_record_id(exist_node)
                     # onlu generating CRDC ID for valid nodes
                     valid_crdc_id_nodes = type in main_node_types
-                    # principal investigator node
-                    if type == PRINCIPAL_INVESTIGATOR and PRINCIPAL_INVESTIGATOR in main_node_types:
-                        crdc_id = self.ORCID
-                    else:
-                        crdc_id = self.get_crdc_id(exist_node, type, node_id, self.submission.get(STUDY_ID)) if valid_crdc_id_nodes else None
+                    if valid_crdc_id_nodes:
+                        crdc_id = self.get_crdc_id(exist_node, type, node_id, self.submission.get(STUDY_ID)) if type != PRINCIPAL_INVESTIGATOR else self.ORCID
                     # file nodes
                     if valid_crdc_id_nodes and type in file_types:
                         id_field = self.file_nodes.get(type, {}).get(ID_FIELD)


### PR DESCRIPTION
Found an unnecessary db call for each PRINCIPAL_INVESTIGATOR node.   Please try if the performance are improved.   2-3 seconds/ 208 nodes as tested in local.   If still not good enough, need add index for studyID in submission collection and composition index in dataRecord for entityType, nodeId, submissionID.  The problem is there are some composition index already.