### PR TITLE
Fixed 2505

### DIFF
--- a/src/common/model_reader.py
+++ b/src/common/model_reader.py
@@ -295,7 +295,7 @@ class YamlModelParser:
                 if not re.search(r'://', t):
                     enum.add(t)
             if len(enum) > 0:
-                return {TYPE: DEFAULT_TYPE, ALLOWED_VALUES: enum}
+                return {TYPE: DEFAULT_TYPE, ALLOWED_VALUES: list(enum)}
             else:
                 return None
         else:


### PR DESCRIPTION
The issue is caused by model reader is not convert set of enum values to list.   After minor change the issue is fixed.  The reason why new version of data models has no such issue is because use CDE PV list instead based on term section.