### PR TITLE
CRDCDH-2494-002

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -215,7 +215,12 @@ class DataLoader:
             val = rawData.get(relation)
             if val:
                 temp = relation.split('.')
-                parents.append({"parentType": temp[0], "parentIDPropName": temp[1], "parentIDValue": val})
+                if "|" in val:
+                    val_list = val.split("|")
+                    for iVal in val_list:
+                        parents.append({"parentType": temp[0], "parentIDPropName": temp[1], "parentIDValue": iVal.strip()})
+                else:
+                    parents.append({"parentType": temp[0], "parentIDPropName": temp[1], "parentIDValue": val})
                 rawData.update({relation.replace(".", "|"): val})
         return parents
     


### PR DESCRIPTION
Updated data_loader.py to handle new format parents in the format of "pID_1|pID-2....", Processed parents will be saved as usual in DB, parents: [{parentType: file, parentIDPropName: study, parentPropVal: 12345}, ...]