### PR TITLE
Avoid duplicate file node with different case

### DIFF
--- a/src/common/mongo_dao.py
+++ b/src/common/mongo_dao.py
@@ -509,7 +509,7 @@ class MongoDao:
         db = self.client[self.db_name]
         file_collection = db[DATA_COLlECTION]
         try:
-            result = file_collection.find_one({SUBMISSION_ID: submission_id, NODE_ID: nodeID, NODE_TYPE: nodeType})
+            result = file_collection.find_one({SUBMISSION_ID: submission_id, NODE_ID: { "$regex": nodeID, "$options": "i" }, NODE_TYPE: nodeType})
             return result
         except errors.PyMongoError as pe:
             self.log.exception(pe)

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -60,7 +60,9 @@ class DataLoader:
 
                 for index, row in df.iterrows():
                     type = row[TYPE]
-                    node_id = self.get_node_id(type, row)
+                    node_id = self.get_node_id(type, row)  #convert the file_id to correct format.
+                    if type in file_types:
+                        node_id = self.adjust_file_id_case(node_id)
                     exist_node = self.mongo_dao.get_dataRecord_by_node(node_id, type, self.batch[SUBMISSION_ID])
                     # add logic to delete QC record if exist_node
                     if exist_node and exist_node.get(QC_RESULT_ID): 
@@ -122,8 +124,6 @@ class DataLoader:
                             dataRecord["CRDC_ID"] = crdc_id
                         if type in file_types:
                             dataRecord[S3_FILE_INFO] = self.get_file_info(type, prop_names, row)
-                            dataRecord[NODE_ID] = self.adjust_file_id_case(node_id)
-
                         records.append(dataRecord)
                     failed_at += 1
 


### PR DESCRIPTION
Avoid duplicate file node with different case by modified the DAO function, get_dataRecord_by_node(self, nodeID, nodeType, submission_id), make the nodeId filter case-insensitive.