### PR TITLE
CRDCDH-3642

### DIFF
--- a/src/pv_puller_v2.py
+++ b/src/pv_puller_v2.py
@@ -166,7 +166,9 @@ def extract_pv_list(property_pv_list):
     """
     extract pv list from property pv list
     """
-    pv_list = None
+    pv_list = []
+    if property_pv_list is None:
+        pv_list = None
     if property_pv_list and len(property_pv_list) > 0 and property_pv_list[0].get(NCIT_VALUE): 
         pv_list = [item.get(NCIT_VALUE) for item in property_pv_list if item.get(NCIT_VALUE) is not None]
     if property_pv_list and any(item.get(NCIT_VALUE) for item in property_pv_list):

--- a/src/pv_puller_v2.py
+++ b/src/pv_puller_v2.py
@@ -169,13 +169,8 @@ def extract_pv_list(property_pv_list):
     pv_list = []
     if property_pv_list is None:
         pv_list = None
-    if property_pv_list and len(property_pv_list) > 0 and property_pv_list[0].get(NCIT_VALUE): 
-        pv_list = [item.get(NCIT_VALUE) for item in property_pv_list if item.get(NCIT_VALUE) is not None]
     if property_pv_list and any(item.get(NCIT_VALUE) for item in property_pv_list):
         pv_list = [item[NCIT_VALUE] for item in property_pv_list if NCIT_VALUE in item and item[NCIT_VALUE] is not None]
-        contains_http = any(s for s in pv_list if isinstance(s, str) and s.startswith(("http:", "https:")))
-        if contains_http:
-            return None
         # strip white space if the value is a string
         if pv_list and isinstance(pv_list[0], str): 
             pv_list = [item.strip() for item in pv_list]

--- a/src/test/test_pv_puller_v2.py
+++ b/src/test/test_pv_puller_v2.py
@@ -426,7 +426,7 @@ def test_extract_pv_list_empty():
     """Test extraction from empty list"""
     result = extract_pv_list([])
     
-    assert result is None
+    assert result == []
 
 
 def test_extract_pv_list_none_values():


### PR DESCRIPTION
updated the pv puller to upload empty list to the DB if empty list is given by MDB api

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how permissible values are normalized before DB upsert, including no longer dropping URL-like values; this can alter stored data shape/content and may impact downstream consumers expecting `null` filtering.
> 
> **Overview**
> **PV extraction now preserves empties.** `extract_pv_list` returns an empty list (`[]`) when the API provides an empty permissible-values array, while keeping `None` as `None`.
> 
> **Filtering behavior changed.** The prior early-return that dropped PV lists containing `http:`/`https:` values was removed, so those values will now be retained. Tests were updated to expect `[]` for the empty-list case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ad67e727f0a55b8fa8ee9dda3302e8def407226. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->